### PR TITLE
Add -pkg.el file

### DIFF
--- a/ztree-pkg.el
+++ b/ztree-pkg.el
@@ -1,0 +1,1 @@
+(define-package "ztree" "1.0.0"  "Several text-tree applications")


### PR DESCRIPTION
Hi, I plan to add this to [MELPA](http://melpa.milkbox.net/), This commit makes `ztree` installable with `package.el`. Feel free to change a description if desired. For information about this fix, See GNU Emacs Manual, [Multi-file Packages](http://www.gnu.org/software/emacs/manual/html_node/elisp/Multi_002dfile-Packages.html).
