### PR TITLE
Add autoload cookies

### DIFF
--- a/ztree-diff.el
+++ b/ztree-diff.el
@@ -403,7 +403,7 @@ apparently shall not be visible"
   (setq ztree-diff-show-equal-files (not ztree-diff-show-equal-files))
   (ztree-refresh-buffer))
 
-
+;;;###autoload
 (defun ztree-diff (dir1 dir2)
   "Creates an interactive buffer with the directory tree of the path given"
   (interactive "DLeft directory \nDRight directory ")

--- a/ztree-dir.el
+++ b/ztree-dir.el
@@ -89,6 +89,7 @@ including . and ..")
   (not (string-match ztree-hidden-files-regexp
                      (file-short-name filename))))
 
+;;;###autoload
 (defun ztree-dir (path)
   "Creates an interactive buffer with the directory tree of the path given"
   (interactive "DDirectory: ")


### PR DESCRIPTION
This commit ensures that users who have installed `ztree` from [MELPA](http://melpa.milkbox.net/)  will be able to use `ztree-diff` or `ztree-dir` without explicitly requiring the library first.
