### PR TITLE
Address #38, #39

### DIFF
--- a/ztree-diff.el
+++ b/ztree-diff.el
@@ -95,7 +95,7 @@ By default paths starting with dot (like .git) are ignored")
 (defvar-local ztree-diff-wait-message nil
   "Message showing while constructing the diff tree.")
 
-(defvar ztree-diff--ediff-previous-window-configuration nil
+(defvar-local ztree-diff-ediff-previous-window-configuration nil
   "Window configuration prior to calling `ediff'.")
 
 ;;;###autoload

--- a/ztree-diff.el
+++ b/ztree-diff.el
@@ -241,7 +241,6 @@ This hook function removes itself."
 See the Info node `(ediff) hooks'.
 
 This hook function removes itself."
-  (ediff-kill-buffer-carefully ediff-registry-buffer)
   (set-window-configuration ztree-diff--ediff-previous-window-configuration)
   (remove-hook 'ediff-quit-hook #'ztree-diff-ediff-quit-hook-function))
 

--- a/ztree-diff.el
+++ b/ztree-diff.el
@@ -95,6 +95,8 @@ By default paths starting with dot (like .git) are ignored")
 (defvar-local ztree-diff-wait-message nil
   "Message showing while constructing the diff tree.")
 
+(defvar ztree-diff--ediff-previous-window-configuration nil
+  "Window configuration prior to calling `ediff'.")
 
 ;;;###autoload
 (define-minor-mode ztreediff-mode
@@ -224,6 +226,34 @@ Argument NODE node containing paths to files to call a diff on."
       (let ((node (car found)))
         (ztree-diff-simple-diff node)))))
 
+(defun ztree-diff-ediff-before-setup-hook-function ()
+  "Hook function for `ediff-before-setup-hook'.
+
+See the Info node `(ediff) hooks'.
+
+This hook function removes itself."
+  (setq ztree-diff--ediff-previous-window-configuration (current-window-configuration))
+  (remove-hook 'ediff-before-setup-hook #'ztree-diff-ediff-before-setup-hook-function))
+
+(defun ztree-diff-ediff-quit-hook-function ()
+  "Hook function for `ediff-quit-hook'.
+
+See the Info node `(ediff) hooks'.
+
+This hook function removes itself."
+  (ediff-kill-buffer-carefully ediff-registry-buffer)
+  (set-window-configuration ztree-diff--ediff-previous-window-configuration)
+  (remove-hook 'ediff-quit-hook #'ztree-diff-ediff-quit-hook-function))
+
+(defun ztree-diff-ediff (file-a file-b &optional startup-hooks)
+  "Ediff that cleans up after itself.
+
+Ediff-related buffers are killed and the pre-Ediff window
+configuration is restored."
+  (add-hook 'ediff-before-setup-hook #'ztree-diff-ediff-before-setup-hook-function)
+  (add-hook 'ediff-quit-hook #'ztree-diff-ediff-quit-hook-function t)
+  (ediff file-a file-b startup-hooks))
+
 (defun ztree-diff-node-action (node hard)
   "Perform action on NODE:
 1 if both left and right sides present:
@@ -243,7 +273,7 @@ Argument NODE node containing paths to files to call a diff on."
            (if (eql (ztree-diff-node-different node) 'same)
                (funcall open-f left)
              (if hard
-                 (ediff left right)
+                 (ztree-diff-ediff left right)
                (ztree-diff-simple-diff node))))
           (left (funcall open-f left))
           (right (funcall open-f right))


### PR DESCRIPTION
Clean up Ediff buffers and restore window configuration (back to `ztree`)
after quitting Ediff session.

**Note**: I have signed the FSF's contributor agreement.